### PR TITLE
Removing --import-path special case

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -216,14 +216,6 @@ exports.buildArgsArray = function (options) {
         'watch'
     ]));
 
-    // Compass doesn't have a long flag for this option:
-    // https://github.com/chriseppstein/compass/issues/1055
-    if (options.importPath) {
-        args = args.map(function (el) {
-            return el.replace('--import-path', '-I');
-        });
-    }
-
     return args;
 };
 


### PR DESCRIPTION
The special case handler for the `--import-path` option is not needed. See: https://github.com/Compass/compass/pull/1138/files
